### PR TITLE
Switch project to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,16 +5,17 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- adopt ESM by changing package.json `type` to `module`
- enable esModuleInterop and bundler-style module resolution in tsconfig
- expose Vite client types for TypeScript

## Testing
- `npm install`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687cfa9657c0832e8ab15804377e10bd