### PR TITLE
Remove Prototype label

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ const App: React.FC = () => {
 
   return (
     <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">DJ Mix Console (Prototype)</h1>
+      <h1 className="text-xl font-bold mb-4">DJ Mix Console</h1>
       <input type="file" accept="audio/*" multiple onChange={onFileChange} />
       <div className="grid grid-cols-2 gap-4 mt-4">
         <div>


### PR DESCRIPTION
## Summary
- remove the "(Prototype)" suffix from the app header

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d02a5ca2c832eb289a19879274ab4