### PR TITLE
Fix certbot usage when reusing existing certificate

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -186,6 +186,9 @@ NGINX
   if [ "$CERT_EXIST" = "no" ]; then
     certbot --nginx -d "$DOMAIN" -d "www.$DOMAIN" \
       --non-interactive --agree-tos -m "$EMAIL" --redirect
+  else
+    certbot --nginx -d "$DOMAIN" -d "www.$DOMAIN" \
+      --non-interactive --redirect
   fi
 
   systemctl reload nginx


### PR DESCRIPTION
## Summary
- call certbot even when an existing certificate is chosen during install/reinstall

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d16856d4c832e82ccb21273d1788d