### PR TITLE
Add basic mixer UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import DeckWrapper from './components/Deck/DeckWrapper';
+import Mixer from './components/Mixer';
 import './style.css';
 
 const App: React.FC = () => {
   const [files, setFiles] = useState<File[]>([]);
+  const leftRef = useRef<HTMLAudioElement>(null);
+  const rightRef = useRef<HTMLAudioElement>(null);
 
   const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
@@ -17,9 +20,10 @@ const App: React.FC = () => {
     <div className="p-4">
       <h1 className="text-xl font-bold mb-4">DJ Mix Console</h1>
       <input type="file" accept="audio/*" multiple onChange={onFileChange} />
-      <div className="grid grid-cols-2 gap-4 mt-4">
-        <DeckWrapper initialType="cdj" files={files} name="Left Deck" />
-        <DeckWrapper initialType="cdj" files={files} name="Right Deck" />
+      <div className="grid grid-cols-3 gap-4 mt-4 items-start">
+        <DeckWrapper initialType="cdj" files={files} name="Left Deck" audioRef={leftRef} />
+        <Mixer leftRef={leftRef} rightRef={rightRef} />
+        <DeckWrapper initialType="cdj" files={files} name="Right Deck" audioRef={rightRef} />
       </div>
     </div>
   );

--- a/src/components/CDJ3000.tsx
+++ b/src/components/CDJ3000.tsx
@@ -3,12 +3,18 @@ import React, { useRef, useState } from 'react';
 interface Props {
   files: File[];
   name: string;
+  /**
+   * Optional ref to expose the underlying audio element.
+   * Allows the mixer component to control volume/crossfader.
+   */
+  audioRef?: React.RefObject<HTMLAudioElement>;
 }
 
 // Simple placeholder implementation of a Pioneer CDJ-3000 deck.
 // Offers basic audio playback functionality for now.
-const CDJ3000: React.FC<Props> = ({ files, name }) => {
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+const CDJ3000: React.FC<Props> = ({ files, name, audioRef }) => {
+  const internalRef = useRef<HTMLAudioElement | null>(null);
+  const ref = audioRef ?? internalRef;
   const [selected, setSelected] = useState<string>('');
 
   const loadTrack = (file: File) => {
@@ -17,17 +23,17 @@ const CDJ3000: React.FC<Props> = ({ files, name }) => {
   };
 
   const play = () => {
-    audioRef.current?.play();
+    ref.current?.play();
   };
 
   const pause = () => {
-    audioRef.current?.pause();
+    ref.current?.pause();
   };
 
   return (
     <div className="border p-2">
       <h2 className="font-semibold mb-2">{name} – CDJ‑3000</h2>
-      <audio ref={audioRef} src={selected} controls className="w-full" />
+      <audio ref={ref} src={selected} controls className="w-full" />
       <div className="mt-2 space-x-2">
         {files.map((file) => (
           <button

--- a/src/components/Deck/DeckWrapper.tsx
+++ b/src/components/Deck/DeckWrapper.tsx
@@ -9,9 +9,11 @@ interface DeckWrapperProps {
   initialType: DeckType;
   files: File[];
   name: string;
+  /** Ref to access the deck's audio element */
+  audioRef: React.RefObject<HTMLAudioElement>;
 }
 
-const DeckWrapper: React.FC<DeckWrapperProps> = ({ initialType, files, name }) => {
+const DeckWrapper: React.FC<DeckWrapperProps> = ({ initialType, files, name, audioRef }) => {
   const [type, setType] = React.useState<DeckType>(() => {
     const saved = localStorage.getItem(`${name}-deck-type`);
     return (saved as DeckType) || initialType;
@@ -25,9 +27,9 @@ const DeckWrapper: React.FC<DeckWrapperProps> = ({ initialType, files, name }) =
     <div>
       <DeckSelect value={type} onChange={setType} label={name} />
       {type === 'cdj' ? (
-        <CDJ3000 files={files} name={name} />
+        <CDJ3000 files={files} name={name} audioRef={audioRef} />
       ) : (
-        <SL1200 files={files} name={name} />
+        <SL1200 files={files} name={name} audioRef={audioRef} />
       )}
     </div>
   );

--- a/src/components/Mixer.tsx
+++ b/src/components/Mixer.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react'
+
+interface Props {
+  leftRef: React.RefObject<HTMLAudioElement>
+  rightRef: React.RefObject<HTMLAudioElement>
+}
+
+const Mixer: React.FC<Props> = ({ leftRef, rightRef }) => {
+  const [cross, setCross] = useState(0.5)
+  const [leftVol, setLeftVol] = useState(1)
+  const [rightVol, setRightVol] = useState(1)
+
+  useEffect(() => {
+    if (leftRef.current) leftRef.current.volume = leftVol * (1 - cross)
+  }, [leftRef, leftVol, cross])
+
+  useEffect(() => {
+    if (rightRef.current) rightRef.current.volume = rightVol * cross
+  }, [rightRef, rightVol, cross])
+
+  return (
+    <div className="border p-2 flex flex-col items-center">
+      <h2 className="font-semibold mb-2">Mixer</h2>
+      <div className="flex items-end space-x-4">
+        <div className="flex flex-col items-center">
+          <label className="text-xs mb-1">Ch1</label>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={leftVol}
+            onChange={e => setLeftVol(parseFloat(e.target.value))}
+            className="h-32 rotate-[-90deg]"
+          />
+        </div>
+        <div className="flex flex-col items-center">
+          <label className="text-xs mb-1">Crossfader</label>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={cross}
+            onChange={e => setCross(parseFloat(e.target.value))}
+            className="w-32"
+          />
+        </div>
+        <div className="flex flex-col items-center">
+          <label className="text-xs mb-1">Ch2</label>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={rightVol}
+            onChange={e => setRightVol(parseFloat(e.target.value))}
+            className="h-32 rotate-[-90deg]"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Mixer

--- a/src/components/SL1200.tsx
+++ b/src/components/SL1200.tsx
@@ -3,14 +3,20 @@ import React, { useRef, useState } from 'react';
 interface Props {
   files: File[];
   name: string;
+  /**
+   * Optional ref to expose the underlying audio element
+   * for mixer volume control.
+   */
+  audioRef?: React.RefObject<HTMLAudioElement>;
 }
 
 /**
  * Basic representation of the Technics SL‑1200G turntable based on
  * the operating instructions. Only simplified controls are provided.
  */
-const SL1200: React.FC<Props> = ({ files, name }) => {
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+const SL1200: React.FC<Props> = ({ files, name, audioRef }) => {
+  const internalRef = useRef<HTMLAudioElement | null>(null);
+  const ref = audioRef ?? internalRef;
   const [selected, setSelected] = useState<string>('');
   const [isRunning, setIsRunning] = useState(false);
   const [pitchRange, setPitchRange] = useState(0.08); // ±8 % default
@@ -23,11 +29,11 @@ const SL1200: React.FC<Props> = ({ files, name }) => {
   };
 
   const startStop = () => {
-    if (!audioRef.current) return;
+    if (!ref.current) return;
     if (isRunning) {
-      audioRef.current.pause();
+      ref.current.pause();
     } else {
-      audioRef.current.play();
+      ref.current.play();
     }
     setIsRunning(!isRunning);
   };
@@ -35,25 +41,25 @@ const SL1200: React.FC<Props> = ({ files, name }) => {
   const toggleRange = () => {
     setPitchRange(pitchRange === 0.08 ? 0.16 : 0.08);
     setPitch(0);
-    if (audioRef.current) audioRef.current.playbackRate = 1;
+    if (ref.current) ref.current.playbackRate = 1;
   };
 
   const resetPitch = () => {
     setPitch(0);
-    if (audioRef.current) audioRef.current.playbackRate = 1;
+    if (ref.current) ref.current.playbackRate = 1;
   };
 
   const changePitch = (value: number) => {
     setPitch(value);
-    if (audioRef.current) {
-      audioRef.current.playbackRate = 1 + value;
+    if (ref.current) {
+      ref.current.playbackRate = 1 + value;
     }
   };
 
   return (
     <div className="border p-2">
       <h2 className="font-semibold mb-2">{name} – Technics SL‑1200</h2>
-      <audio ref={audioRef} src={selected} />
+      <audio ref={ref} src={selected} />
       <div className="mt-2 space-x-2">
         {files.map((file) => (
           <button


### PR DESCRIPTION
## Summary
- expose deck audio refs
- add Mixer component with crossfader and channel faders
- show mixer between decks

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d17a971a0832e8f933434a4da1903