### PR TITLE
Implement advanced deck and mixer UI

### DIFF
--- a/src/components/CDJ3000.tsx
+++ b/src/components/CDJ3000.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface Props {
   files: File[];
@@ -16,6 +16,8 @@ const CDJ3000: React.FC<Props> = ({ files, name, audioRef }) => {
   const internalRef = useRef<HTMLAudioElement | null>(null);
   const ref = audioRef ?? internalRef;
   const [selected, setSelected] = useState<string>('');
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [dragging, setDragging] = useState(false);
 
   const loadTrack = (file: File) => {
     const url = URL.createObjectURL(file);
@@ -30,10 +32,55 @@ const CDJ3000: React.FC<Props> = ({ files, name, audioRef }) => {
     ref.current?.pause();
   };
 
+  const onMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!dragging || !ref.current) return;
+    ref.current.currentTime += e.movementX * 0.01;
+  };
+
+  useEffect(() => {
+    if (!selected || !canvasRef.current) return;
+    const ctx = new AudioContext();
+    fetch(selected)
+      .then(r => r.arrayBuffer())
+      .then(b => ctx.decodeAudioData(b))
+      .then(drawWaveform);
+
+    function drawWaveform(buffer: AudioBuffer) {
+      const canvas = canvasRef.current!;
+      const c = canvas.getContext('2d');
+      if (!c) return;
+      const data = buffer.getChannelData(0);
+      const step = Math.ceil(data.length / canvas.width);
+      c.clearRect(0, 0, canvas.width, canvas.height);
+      for (let i = 0; i < canvas.width; i++) {
+        let min = 1.0;
+        let max = -1.0;
+        for (let j = 0; j < step; j++) {
+          const val = data[i * step + j];
+          if (val < min) min = val;
+          if (val > max) max = val;
+        }
+        const y1 = ((1 + min) * canvas.height) / 2;
+        const y2 = ((1 + max) * canvas.height) / 2;
+        c.fillRect(i, y1, 1, y2 - y1);
+      }
+    }
+  }, [selected]);
+
   return (
     <div className="border p-2">
       <h2 className="font-semibold mb-2">{name} – CDJ‑3000</h2>
       <audio ref={ref} src={selected} controls className="w-full" />
+      <canvas ref={canvasRef} width={300} height={60} className="w-full mt-2 bg-gray-900" />
+      <div
+        className="jogwheel mx-auto my-4"
+        onMouseDown={() => setDragging(true)}
+        onMouseUp={() => setDragging(false)}
+        onMouseLeave={() => setDragging(false)}
+        onMouseMove={onMouseMove}
+      >
+        <div className="marker" />
+      </div>
       <div className="mt-2 space-x-2">
         {files.map((file) => (
           <button

--- a/src/components/Mixer.tsx
+++ b/src/components/Mixer.tsx
@@ -10,6 +10,17 @@ const Mixer: React.FC<Props> = ({ leftRef, rightRef }) => {
   const [leftVol, setLeftVol] = useState(1)
   const [rightVol, setRightVol] = useState(1)
 
+  const [gainL, setGainL] = useState(0)
+  const [gainR, setGainR] = useState(0)
+
+  const [eqLHigh, setEqLHigh] = useState(0)
+  const [eqLMid, setEqLMid] = useState(0)
+  const [eqLLow, setEqLLow] = useState(0)
+
+  const [eqRHigh, setEqRHigh] = useState(0)
+  const [eqRMid, setEqRMid] = useState(0)
+  const [eqRLow, setEqRLow] = useState(0)
+
   useEffect(() => {
     if (leftRef.current) leftRef.current.volume = leftVol * (1 - cross)
   }, [leftRef, leftVol, cross])
@@ -21,9 +32,45 @@ const Mixer: React.FC<Props> = ({ leftRef, rightRef }) => {
   return (
     <div className="border p-2 flex flex-col items-center">
       <h2 className="font-semibold mb-2">Mixer</h2>
-      <div className="flex items-end space-x-4">
-        <div className="flex flex-col items-center">
-          <label className="text-xs mb-1">Ch1</label>
+      <div className="flex space-x-8">
+        {/* Channel 1 */}
+        <div className="flex flex-col items-center space-y-2">
+          <input
+            type="range"
+            min={-12}
+            max={12}
+            step={1}
+            value={gainL}
+            onChange={e => setGainL(parseFloat(e.target.value))}
+            className="gain-fader"
+          />
+          <input
+            type="range"
+            min={-12}
+            max={12}
+            step={1}
+            value={eqLHigh}
+            onChange={e => setEqLHigh(parseFloat(e.target.value))}
+            className="eq-fader"
+          />
+          <input
+            type="range"
+            min={-12}
+            max={12}
+            step={1}
+            value={eqLMid}
+            onChange={e => setEqLMid(parseFloat(e.target.value))}
+            className="eq-fader"
+          />
+          <input
+            type="range"
+            min={-12}
+            max={12}
+            step={1}
+            value={eqLLow}
+            onChange={e => setEqLLow(parseFloat(e.target.value))}
+            className="eq-fader"
+          />
           <input
             type="range"
             min={0}
@@ -31,11 +78,12 @@ const Mixer: React.FC<Props> = ({ leftRef, rightRef }) => {
             step={0.01}
             value={leftVol}
             onChange={e => setLeftVol(parseFloat(e.target.value))}
-            className="h-32 rotate-[-90deg]"
+            className="volume-fader"
           />
+          <button className="cue-button">Cue</button>
         </div>
-        <div className="flex flex-col items-center">
-          <label className="text-xs mb-1">Crossfader</label>
+
+        <div className="flex flex-col justify-end w-32">
           <input
             type="range"
             min={0}
@@ -43,11 +91,48 @@ const Mixer: React.FC<Props> = ({ leftRef, rightRef }) => {
             step={0.01}
             value={cross}
             onChange={e => setCross(parseFloat(e.target.value))}
-            className="w-32"
+            className="crossfader"
           />
         </div>
-        <div className="flex flex-col items-center">
-          <label className="text-xs mb-1">Ch2</label>
+
+        {/* Channel 2 */}
+        <div className="flex flex-col items-center space-y-2">
+          <input
+            type="range"
+            min={-12}
+            max={12}
+            step={1}
+            value={gainR}
+            onChange={e => setGainR(parseFloat(e.target.value))}
+            className="gain-fader"
+          />
+          <input
+            type="range"
+            min={-12}
+            max={12}
+            step={1}
+            value={eqRHigh}
+            onChange={e => setEqRHigh(parseFloat(e.target.value))}
+            className="eq-fader"
+          />
+          <input
+            type="range"
+            min={-12}
+            max={12}
+            step={1}
+            value={eqRMid}
+            onChange={e => setEqRMid(parseFloat(e.target.value))}
+            className="eq-fader"
+          />
+          <input
+            type="range"
+            min={-12}
+            max={12}
+            step={1}
+            value={eqRLow}
+            onChange={e => setEqRLow(parseFloat(e.target.value))}
+            className="eq-fader"
+          />
           <input
             type="range"
             min={0}
@@ -55,8 +140,9 @@ const Mixer: React.FC<Props> = ({ leftRef, rightRef }) => {
             step={0.01}
             value={rightVol}
             onChange={e => setRightVol(parseFloat(e.target.value))}
-            className="h-32 rotate-[-90deg]"
+            className="volume-fader"
           />
+          <button className="cue-button">Cue</button>
         </div>
       </div>
     </div>

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,67 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .volume-fader,
+  .eq-fader,
+  .gain-fader,
+  .crossfader {
+    appearance: none;
+    border-radius: 0.25rem;
+    position: relative;
+    background-color: #374151; /* gray-700 */
+  }
+
+  .volume-fader::-webkit-slider-thumb,
+  .eq-fader::-webkit-slider-thumb,
+  .gain-fader::-webkit-slider-thumb,
+  .crossfader::-webkit-slider-thumb {
+    appearance: none;
+    border-radius: 9999px;
+    cursor: pointer;
+    background-color: #d1d5db; /* gray-300 */
+    width: 14px;
+    height: 14px;
+  }
+
+  .volume-fader,
+  .eq-fader,
+  .gain-fader {
+    width: 8px;
+    height: 100px;
+    writing-mode: bt-lr;
+    transform: rotate(180deg);
+  }
+
+  .crossfader {
+    height: 10px;
+    width: 100%;
+  }
+
+  .cue-button {
+    background-color: #f97316; /* orange-500 */
+    color: white;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+  }
+
+  .jogwheel {
+    position: relative;
+    user-select: none;
+    border-radius: 9999px;
+    background-color: #1f2937; /* gray-800 */
+    width: 160px;
+    height: 160px;
+  }
+
+  .jogwheel .marker {
+    position: absolute;
+    background-color: #ffffff;
+    width: 2px;
+    height: 20px;
+    left: 50%;
+    top: 0;
+    transform: translateX(-50%);
+  }
+}


### PR DESCRIPTION
## Summary
- enhance mixer with gain/EQ faders and cue buttons
- add jogwheel and waveform canvas to CDJ component
- style faders and jogwheel with new CSS utilities

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d199c8724832e9860a194f8c6097c