### PR TITLE
Modernize deck interface with icons and waveform

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -162,6 +162,7 @@ do_install() {
   rsync -a --exclude=".git" "$REPO_DIR/" "$TARGET_DIR/"
   cd "$TARGET_DIR"
   npm install
+  npm update
   npm run build
 
   NGINX_CONF="/etc/nginx/sites-available/${DOMAIN}"
@@ -211,6 +212,7 @@ do_update() {
   rsync -a --exclude=".git" "$REPO_DIR/" "$TARGET_DIR/"
   cd "$TARGET_DIR"
   npm install
+  npm update
   npm run build
   systemctl reload nginx
   echo "Update complete for $DOMAIN"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -869,6 +872,52 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
     },
     "node_modules/@headlessui/react": {
       "version": "2.2.4",
@@ -2144,7 +2193,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -2412,6 +2460,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2521,6 +2581,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2577,6 +2646,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -2597,6 +2677,12 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
   "type": "module",
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@fortawesome/react-fontawesome": "^0.2.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/fontawesome-svg-core": "^6.7.2"
   },
   "devDependencies": {
     "@headlessui/react": "^2.2.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,9 +21,9 @@ const App: React.FC = () => {
       <h1 className="text-xl font-bold mb-4">DJ Mix Console</h1>
       <input type="file" accept="audio/*" multiple onChange={onFileChange} className="mb-4" />
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4 items-start">
-        <DeckWrapper initialType="cdj" files={files} name="Left Deck" audioRef={leftRef} />
+        <DeckWrapper initialType="cdj" files={files} name="Left Deck" color="cyan" audioRef={leftRef} />
         <Mixer leftRef={leftRef} rightRef={rightRef} />
-        <DeckWrapper initialType="cdj" files={files} name="Right Deck" audioRef={rightRef} />
+        <DeckWrapper initialType="cdj" files={files} name="Right Deck" color="red" audioRef={rightRef} />
       </div>
     </div>
   );

--- a/src/components/Deck/DeckWrapper.tsx
+++ b/src/components/Deck/DeckWrapper.tsx
@@ -9,11 +9,12 @@ interface DeckWrapperProps {
   initialType: DeckType;
   files: File[];
   name: string;
+  color: string;
   /** Ref to access the deck's audio element */
   audioRef: React.RefObject<HTMLAudioElement>;
 }
 
-const DeckWrapper: React.FC<DeckWrapperProps> = ({ initialType, files, name, audioRef }) => {
+const DeckWrapper: React.FC<DeckWrapperProps> = ({ initialType, files, name, color, audioRef }) => {
   const [type, setType] = React.useState<DeckType>(() => {
     const saved = localStorage.getItem(`${name}-deck-type`);
     return (saved as DeckType) || initialType;
@@ -27,7 +28,7 @@ const DeckWrapper: React.FC<DeckWrapperProps> = ({ initialType, files, name, aud
     <div>
       <DeckSelect value={type} onChange={setType} label={name} />
       {type === 'cdj' ? (
-        <CDJ3000 files={files} name={name} audioRef={audioRef} />
+        <CDJ3000 files={files} name={name} color={color} audioRef={audioRef} />
       ) : (
         <SL1200 files={files} name={name} audioRef={audioRef} />
       )}

--- a/src/components/Touchscreen.tsx
+++ b/src/components/Touchscreen.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from 'react';
+
+interface Props {
+  src: string;
+  audioRef: React.RefObject<HTMLAudioElement>;
+  color: string;
+}
+
+const Touchscreen: React.FC<Props> = ({ src, audioRef, color }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!src || !canvas) return;
+    const ctx = new AudioContext();
+    let raf: number;
+
+    fetch(src)
+      .then(r => r.arrayBuffer())
+      .then(b => ctx.decodeAudioData(b))
+      .then(buffer => {
+        const c = canvas.getContext('2d');
+        if (!c) return;
+        const data = buffer.getChannelData(0);
+        const step = Math.ceil(data.length / canvas.width);
+        c.fillStyle = '#1f2937';
+        c.fillRect(0, 0, canvas.width, canvas.height);
+        c.fillStyle = '#6b7280';
+        for (let i = 0; i < canvas.width; i++) {
+          let min = 1.0;
+          let max = -1.0;
+          for (let j = 0; j < step; j++) {
+            const val = data[i * step + j];
+            if (val < min) min = val;
+            if (val > max) max = val;
+          }
+          const y1 = ((1 + min) * canvas.height) / 2;
+          const y2 = ((1 + max) * canvas.height) / 2;
+          c.fillRect(i, y1, 1, y2 - y1);
+        }
+      });
+
+    const drawProgress = () => {
+      if (!canvas || !audioRef.current) return;
+      const c = canvas.getContext('2d');
+      if (!c) return;
+      const progress =
+        audioRef.current.duration > 0
+          ? audioRef.current.currentTime / audioRef.current.duration
+          : 0;
+      c.fillStyle = `rgba(31,41,55,0.9)`; // gray-800
+      c.fillRect(0, canvas.height - 4, canvas.width, 4);
+      c.fillStyle = color;
+      c.fillRect(0, canvas.height - 4, canvas.width * progress, 4);
+      raf = requestAnimationFrame(drawProgress);
+    };
+    drawProgress();
+
+    return () => cancelAnimationFrame(raf);
+  }, [src, audioRef, color]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={300}
+      height={80}
+      className="w-full bg-gray-800 border border-gray-700 rounded-md"
+    />
+  );
+};
+
+export default Touchscreen;

--- a/src/style.css
+++ b/src/style.css
@@ -58,6 +58,10 @@
     background-color: #fb923c;
   }
 
+  .hotcue-button {
+    @apply py-3 rounded text-sm font-bold transition-all duration-200;
+  }
+
   .play-button {
     @apply bg-green-600 hover:bg-green-500 text-white rounded-full px-4 py-2 shadow-lg;
   }
@@ -74,6 +78,19 @@
     height: 160px;
     background: radial-gradient(circle at center, #4b5563 0%, #1f2937 70%);
     transition: transform 0.1s linear;
+  }
+
+  @keyframes jogspin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .jogwheel.playing {
+    animation: jogspin 3s linear infinite;
   }
 
   .jogwheel .marker {


### PR DESCRIPTION
## Summary
- modernize CDJ-3000 player UI and add progress bar
- add touch screen component for waveform display
- colorize decks and pass color via `DeckWrapper`
- enhance jogwheel animation
- add FontAwesome dependencies
- run `npm update` during install/update

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d1dc87264832ea5c3939b47ea31de