### PR TITLE
Fix missing immer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,7 @@ Jedes Deck kann zwischen CDJ‑3000 und SL‑1200 umgeschaltet werden; die Auswa
 ## Development
 1. npm install
 2. npm run dev
+3. Falls die Build-Phase auf "immer" Bezug nimmt, stelle sicher, dass sowohl
+   `zustand` als auch `immer` installiert sind (bereits in `package.json`
+   hinterlegt).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,16 @@
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "zustand": "^4.5.0",
+        "immer": "^10.0.0"
       },
       "devDependencies": {
         "@headlessui/react": "^2.2.4",
         "@tailwindcss/postcss": "^4.1.11",
-        "@types/react": "^19.1.8",
-        "@types/react-dom": "^19.1.6",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.7.0",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "react-dom": "^18.2.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
-    "@fortawesome/fontawesome-svg-core": "^6.7.2"
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "zustand": "^4.5.0",
+    "immer": "^10.0.0"
   },
   "devDependencies": {
     "@headlessui/react": "^2.2.4",


### PR DESCRIPTION
## Summary
- include Zustand state management and its Immer middleware in package files
- mention optional peer dependencies in README

## Testing
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687d3e1f7664832eb509a01609cebab0