### PR TITLE
Fix install script to keep dependency versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -163,10 +163,9 @@ do_install() {
   ensure_rsync
   rsync -a --exclude=".git" "$APP_SOURCE_DIR/" "$TARGET_DIR/"
   cd "$TARGET_DIR"
-  npm install
+  npm ci
   # Ensure optional peer dependencies are installed
   npm list immer >/dev/null 2>&1 || npm install immer
-  npm update
   npm run build
 
   NGINX_CONF="/etc/nginx/sites-available/${DOMAIN}"
@@ -215,10 +214,9 @@ do_update() {
   ensure_rsync
   rsync -a --exclude=".git" "$APP_SOURCE_DIR/" "$TARGET_DIR/"
   cd "$TARGET_DIR"
-  npm install
+  npm ci
   # Ensure optional peer dependencies are installed
   npm list immer >/dev/null 2>&1 || npm install immer
-  npm update
   npm run build
   systemctl reload nginx
   echo "Update complete for $DOMAIN"


### PR DESCRIPTION
## Summary
- use `npm ci` instead of `npm install && npm update` for a deterministic installation in `install.sh`

This avoids updating packages like React, preventing runtime errors in the generated bundle.

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687d46660840832ea58491faaaf137fb