### PR TITLE
Fix installation instructions and pin deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Jedes Deck kann zwischen CDJ‑3000 und SL‑1200 umgeschaltet werden; die Auswa
 ✅ Ziel: Eine portable, realitätsgetreue DJ-Demo-App, die sich komplett im Browser bedienen lässt – ohne Cloud, ohne Server, ohne KI. Nur du, deine Tracks und zwei virtuelle High-End-Player.
 
 ## Development
-1. npm install
+1. npm ci
 2. npm run dev
 3. Falls die Build-Phase auf "immer" Bezug nimmt, stelle sicher, dass sowohl
    `zustand` als auch `immer` installiert sind (bereits in `package.json`

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
@@ -22,16 +22,16 @@
     "immer": "^10.0.0"
   },
   "devDependencies": {
-    "@headlessui/react": "^2.2.4",
-    "@tailwindcss/postcss": "^4.1.11",
-    "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0",
-    "@vitejs/plugin-react": "^4.7.0",
-    "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.11",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.8.3",
-    "vite": "^7.0.5"
+    "@headlessui/react": "2.2.4",
+    "@tailwindcss/postcss": "4.1.11",
+    "@types/react": "18.2.0",
+    "@types/react-dom": "18.2.0",
+    "@vitejs/plugin-react": "4.7.0",
+    "autoprefixer": "10.4.21",
+    "postcss": "8.5.6",
+    "tailwindcss": "4.1.11",
+    "ts-node": "10.9.2",
+    "typescript": "5.8.3",
+    "vite": "7.0.5"
   }
 }


### PR DESCRIPTION
## Summary
- pin dependency versions in `package.json`
- advise using `npm ci` for development install

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_687d48e7dc84832ebe20a75b113dedfc