### PR TITLE
Fix audio loading and mixer controls

### DIFF
--- a/src/audio.ts
+++ b/src/audio.ts
@@ -1,0 +1,9 @@
+let ctx: AudioContext | null = null;
+
+export function getAudioContext(): AudioContext {
+  if (!ctx) {
+    ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+  }
+  return ctx;
+}
+

--- a/src/components/CDJ3000.tsx
+++ b/src/components/CDJ3000.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { getAudioContext } from '../audio';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlay, faPause } from '@fortawesome/free-solid-svg-icons';
 import Touchscreen from './Touchscreen';
@@ -41,6 +42,8 @@ const CDJ3000: React.FC<Props> = ({ files, name, audioRef, color }) => {
   };
 
   const play = () => {
+    const ctx = getAudioContext();
+    ctx.resume();
     ref.current?.play();
   };
 

--- a/src/components/Mixer.tsx
+++ b/src/components/Mixer.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import Knob from './Knob'
+import { getAudioContext } from '../audio'
 
 interface Props {
   leftRef: React.RefObject<HTMLAudioElement>
@@ -7,6 +8,12 @@ interface Props {
 }
 
 const Mixer: React.FC<Props> = ({ leftRef, rightRef }) => {
+  const ctxRef = useRef<AudioContext | null>(null)
+  const leftGain = useRef<GainNode | null>(null)
+  const rightGain = useRef<GainNode | null>(null)
+  const leftFilters = useRef<{ high: BiquadFilterNode; mid: BiquadFilterNode; low: BiquadFilterNode } | null>(null)
+  const rightFilters = useRef<{ high: BiquadFilterNode; mid: BiquadFilterNode; low: BiquadFilterNode } | null>(null)
+
   const [cross, setCross] = useState(0.5)
   const [leftVol, setLeftVol] = useState(1)
   const [rightVol, setRightVol] = useState(1)
@@ -22,13 +29,62 @@ const Mixer: React.FC<Props> = ({ leftRef, rightRef }) => {
   const [eqRMid, setEqRMid] = useState(0)
   const [eqRLow, setEqRLow] = useState(0)
 
+  // Initialize audio routing
   useEffect(() => {
-    if (leftRef.current) leftRef.current.volume = leftVol * (1 - cross)
-  }, [leftRef, leftVol, cross])
+    if (!leftRef.current || !rightRef.current) return
+    const ctx = getAudioContext()
+    ctxRef.current = ctx
+
+    const createChain = (el: HTMLAudioElement) => {
+      const source = ctx.createMediaElementSource(el)
+      const low = ctx.createBiquadFilter()
+      low.type = 'lowshelf'
+      low.frequency.value = 200
+      const mid = ctx.createBiquadFilter()
+      mid.type = 'peaking'
+      mid.frequency.value = 1000
+      const high = ctx.createBiquadFilter()
+      high.type = 'highshelf'
+      high.frequency.value = 8000
+      const gain = ctx.createGain()
+      source.connect(low).connect(mid).connect(high).connect(gain).connect(ctx.destination)
+      return { gain, filters: { high, mid, low } }
+    }
+
+    const left = createChain(leftRef.current)
+    const right = createChain(rightRef.current)
+    leftGain.current = left.gain
+    rightGain.current = right.gain
+    leftFilters.current = left.filters
+    rightFilters.current = right.filters
+
+    return () => {
+      left.gain.disconnect()
+      right.gain.disconnect()
+    }
+  }, [leftRef, rightRef])
+
+  // Apply volume and crossfader
+  useEffect(() => {
+    if (!leftGain.current || !rightGain.current) return
+    leftGain.current.gain.value = (1 - cross) * leftVol * Math.pow(10, gainL / 20)
+    rightGain.current.gain.value = cross * rightVol * Math.pow(10, gainR / 20)
+  }, [cross, leftVol, rightVol, gainL, gainR])
+
+  // Apply EQ changes
+  useEffect(() => {
+    if (!leftFilters.current) return
+    leftFilters.current.high.gain.value = eqLHigh
+    leftFilters.current.mid.gain.value = eqLMid
+    leftFilters.current.low.gain.value = eqLLow
+  }, [eqLHigh, eqLMid, eqLLow])
 
   useEffect(() => {
-    if (rightRef.current) rightRef.current.volume = rightVol * cross
-  }, [rightRef, rightVol, cross])
+    if (!rightFilters.current) return
+    rightFilters.current.high.gain.value = eqRHigh
+    rightFilters.current.mid.gain.value = eqRMid
+    rightFilters.current.low.gain.value = eqRLow
+  }, [eqRHigh, eqRMid, eqRLow])
 
   return (
     <div className="glass-panel flex flex-col items-center">

--- a/src/components/SL1200.tsx
+++ b/src/components/SL1200.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { getAudioContext } from '../audio';
 
 interface Props {
   files: File[];
@@ -33,6 +34,8 @@ const SL1200: React.FC<Props> = ({ files, name, audioRef }) => {
     if (isRunning) {
       ref.current.pause();
     } else {
+      const ctx = getAudioContext();
+      ctx.resume();
       ref.current.play();
     }
     setIsRunning(!isRunning);


### PR DESCRIPTION
## Summary
- add singleton audio context helper
- wire mixer to Web Audio API
- resume audio context when a deck starts

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d65413a08832ea2c380ce32a42437